### PR TITLE
Inline xcb_connection_t definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ travis-ci = { repository = "francesca64/xkbcommon-dl" }
 dlib = "0.4"
 lazy_static = "1.0"
 bitflags = "1.0"
-x11-dl = "2.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate dlib;
 extern crate lazy_static;
 #[macro_use]
 extern crate bitflags;
-extern crate x11_dl;
 
 pub mod keysyms;
 mod x11;

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -1,6 +1,6 @@
 use std::os::raw::c_int;
 
-use x11_dl::xlib_xcb::xcb_connection_t;
+pub type xcb_connection_t = c_void;
 
 use super::*;
 


### PR DESCRIPTION
This is not a breaking change since x11-dl aliased xcb_connection_t to
std::os::raw::c_void and we do the same.

Closes #4